### PR TITLE
Remove type: "module" from package.json

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,11 @@
-on:
-  push
 name:  Deploy website on push
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   web-deploy:
     name:  Deploy

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
       "last 1 safari version"
     ]
   },
-  "type": "module",
   "devDependencies": {
     "typescript": "^4.8.4"
   }


### PR DESCRIPTION
I removed `type: module` from `package.json`. This seems to fix the error that `webpack` was throwing about `react-firebase-hooks`.

I left the `patches/` folder, but it can probably be deleted.

I also updated your GitHub action workflow to only activate when something is pushed or PR'd to the `main` branch 